### PR TITLE
Initialize basic project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# PyInstaller
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.pytest_cache/
+
+# Editor directories and files
+*.swp
+.DS_Store
+coverage.*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # regulens-ai
+
+`regulens-ai` is a minimal Python project intended as a starting point for future
+regulatory analysis tooling. This repository contains a basic package structure
+and documentation to bootstrap development.
+
+## Installation
+Clone the repository and install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+## Documentation
+See the [technical specification](docs/TechSpec.md) for details about the initial
+project structure and planned features.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,10 @@
+"""Entry point for the regulens-ai application."""
+
+
+def main() -> None:
+    """Placeholder main function."""
+    print("regulens-ai is running")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/TechSpec.md
+++ b/docs/TechSpec.md
@@ -1,0 +1,18 @@
+# Technical Specification
+
+This document outlines the initial technical requirements and structure of the **regulens-ai** project. The project aims to provide an extensible Python package for future development. 
+
+## Directory Structure
+- `app/` – Python package containing the application code.
+- `docs/` – Project documentation including this specification.
+
+## Entry Point
+- `app/main.py` will contain the main execution logic. For now it is a placeholder that prints a greeting.
+
+## Installation
+The project is intended to be installed from source using `pip`. The steps are described in the `README.md`.
+
+## Future Work
+- Implement core functionality for regulatory analysis.
+- Add tests and continuous integration workflows.
+


### PR DESCRIPTION
## Summary
- set up initial docs with a technical specification
- create an example Python package in `app/`
- expand the README with installation and doc links
- add a starter `.gitignore`

## Testing
- `pytest -q`