### PR TITLE
Implement async API client & CLI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,3 @@
 """Regulens-AI application package."""
 
-from .main import main
-
-__all__ = ["main"]
+__all__ = []

--- a/app/api_client.py
+++ b/app/api_client.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from urllib import request
+
+try:  # optional dependency for async HTTP
+    import httpx  # type: ignore
+except Exception:  # pragma: no cover - optional
+    httpx = None
 
 
 @dataclass
@@ -13,14 +18,29 @@ class CompareResponse:
 
 
 class ApiClient:
-    """Minimal HTTP client using urllib."""
+    """HTTP client for the RAGCore-X API.
+
+    By default a minimal urllib implementation is used so the library works
+    without optional dependencies. If ``httpx`` is available, the
+    :py:meth:`acompare` method can be used for asynchronous requests.
+    """
 
     def __init__(self, base_url: str, api_key: str, timeout: int = 30) -> None:
         self.base_url = base_url.rstrip('/')
         self.api_key = api_key
         self.timeout = timeout
+        self._async_client: Optional["httpx.AsyncClient"] = None
+        if httpx is not None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=timeout,
+            )
 
-    def compare(self, input_doc: Dict[str, Any], ref_doc: Dict[str, Any], **params: Any) -> CompareResponse:
+    def compare(
+        self, input_doc: Dict[str, Any], ref_doc: Dict[str, Any], **params: Any
+    ) -> CompareResponse:
+        """Perform a synchronous comparison request using ``urllib``."""
         payload = {"input": input_doc, "reference": ref_doc, **params}
         data = json.dumps(payload).encode("utf-8")
         req = request.Request(
@@ -35,3 +55,20 @@ class ApiClient:
             resp_data = resp.read()
         obj = json.loads(resp_data.decode("utf-8"))
         return CompareResponse(result=obj.get("result", ""))
+
+    async def acompare(
+        self, input_doc: Dict[str, Any], ref_doc: Dict[str, Any], **params: Any
+    ) -> CompareResponse:
+        """Asynchronous version using ``httpx`` if available."""
+        if self._async_client is None:
+            raise RuntimeError("httpx is not installed")
+        payload = {"input": input_doc, "reference": ref_doc, **params}
+        resp = await self._async_client.post("/v1/compare", json=payload)
+        resp.raise_for_status()
+        obj = resp.json()
+        return CompareResponse(result=obj.get("result", ""))
+
+    async def aclose(self) -> None:
+        """Close the underlying async client if used."""
+        if self._async_client is not None:
+            await self._async_client.aclose()

--- a/app/compare_manager.py
+++ b/app/compare_manager.py
@@ -30,3 +30,12 @@ class CompareManager:
             return self.api_client.compare(input_doc, ref_doc, **params)
         except Exception as exc:
             raise CompareError(str(exc)) from exc
+
+    async def acompare(self, input_path: Path, ref_path: Path, **params: Any) -> CompareResponse:
+        """Asynchronous wrapper around :meth:`ApiClient.acompare`."""
+        input_doc = self.load_json(input_path)
+        ref_doc = self.load_json(ref_path)
+        try:
+            return await self.api_client.acompare(input_doc, ref_doc, **params)
+        except Exception as exc:
+            raise CompareError(str(exc)) from exc

--- a/app/export.py
+++ b/app/export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from importlib import resources
 
 from markdown_it import MarkdownIt
 
@@ -18,4 +19,15 @@ def to_pdf(markdown_str: str, path: Path) -> None:
     if weasyprint is None:
         raise RuntimeError("weasyprint is not available")
     html = MarkdownIt("commonmark", {"html": True}).render(markdown_str)
-    weasyprint.HTML(string=html).write_pdf(str(path))
+    css = _read_css()
+    html_full = f"<style>{css}</style>{html}"
+    weasyprint.HTML(string=html_full).write_pdf(str(path))
+
+
+def _read_css() -> str:
+    """Return built-in PDF stylesheet."""
+    try:
+        with resources.files("assets").joinpath("pdf.css").open("r", encoding="utf-8") as fh:
+            return fh.read()
+    except Exception:
+        return ""

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,62 @@
-"""Entry point for the Regulens-AI application."""
+"""Entry point for the Regulens-AI application.
+
+This provides a minimal command-line interface that mirrors a subset of the
+planned GUI workflow. It loads API settings from ``config_default.yaml`` and
+outputs the raw Markdown diff to ``stdout`` or a file.
+"""
+
+from pathlib import Path
+import argparse
+import sys
+try:  # optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback for minimal environments
+    yaml = None
+
+from .api_client import ApiClient
+from .compare_manager import CompareManager, CompareError
+from .export import to_pdf, to_txt
 
 
-def main() -> None:
-    print("Regulens-AI placeholder")
+def _load_config(path: Path) -> dict:
+    """Load configuration from YAML without requiring PyYAML."""
+    text = path.read_text()
+    if yaml is not None:
+        return yaml.safe_load(text)
+    data: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" in line:
+            k, v = line.split(":", 1)
+            data[k.strip()] = v.strip().strip('"')
+    return data
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Regulens-AI CLI")
+    parser.add_argument("input", type=Path, help="input JSON file")
+    parser.add_argument("reference", type=Path, help="reference JSON file")
+    parser.add_argument("--txt", type=Path, help="export markdown result")
+    parser.add_argument("--pdf", type=Path, help="export PDF result")
+    args = parser.parse_args(argv)
+
+    cfg = _load_config(Path("config_default.yaml"))
+    client = ApiClient(cfg["base_url"], cfg["api_key"], timeout=cfg.get("timeout", 30))
+    manager = CompareManager(client)
+
+    try:
+        resp = manager.compare(args.input, args.reference)
+    except CompareError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(resp.result)
+    if args.txt:
+        to_txt(resp.result, args.txt)
+    if args.pdf:
+        to_pdf(resp.result, args.pdf)
 
 
 if __name__ == "__main__":

--- a/assets/pdf.css
+++ b/assets/pdf.css
@@ -1,0 +1,2 @@
+body { font-family: Segoe UI, sans-serif; }
+h1,h2,h3 { color: #333333; }


### PR DESCRIPTION
## Summary
- add optional async support to `ApiClient`
- expose async comparison in `CompareManager`
- embed PDF stylesheet and read it when exporting
- provide simple CLI in `main.py`
- include a default `pdf.css`

## Testing
- `pytest -q`